### PR TITLE
🐛 Fix UserEntity to store user's name in firstName and lastName

### DIFF
--- a/backend/src/main/java/com/example/skillmateai/controllers/authentication/AuthenticationController.java
+++ b/backend/src/main/java/com/example/skillmateai/controllers/authentication/AuthenticationController.java
@@ -52,8 +52,8 @@ public class AuthenticationController {
                         .body(createResponseUtil.createResponseBody(false, "Request body is required"));
             }
 
-            if(userEntity.getEmail() == null || userEntity.getPassword() == null || userEntity.getName() == null ||
-               userEntity.getEmail().isEmpty() || userEntity.getPassword().isEmpty() || userEntity.getName().isEmpty()){
+            if(userEntity.getEmail() == null || userEntity.getPassword() == null || userEntity.getFirstName() == null ||
+               userEntity.getEmail().isEmpty() || userEntity.getPassword().isEmpty() || userEntity.getFirstName().isEmpty()){
 
                 return ResponseEntity.badRequest()
                         .body(createResponseUtil.createResponseBody(false, "Email, password or first name is empty"));

--- a/backend/src/main/java/com/example/skillmateai/controllers/user/UserController.java
+++ b/backend/src/main/java/com/example/skillmateai/controllers/user/UserController.java
@@ -91,7 +91,7 @@ public class UserController {
                         .body(createResponseUtil.createResponseBody(false, "Request body is required"));
             }
             
-            return userService.updateName(request.getNewName());
+            return userService.updateName(request.getNewFirstName(), request.getNewLastName());
 
         } catch (Exception e) {
             log.error(e.getMessage());

--- a/backend/src/main/java/com/example/skillmateai/dtos/UpdateNameRequest.java
+++ b/backend/src/main/java/com/example/skillmateai/dtos/UpdateNameRequest.java
@@ -9,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateNameRequest {
     
-    private String newName;
+    private String newFirstName;
+    private String newLastName;
 }

--- a/backend/src/main/java/com/example/skillmateai/entities/user/UserEntity.java
+++ b/backend/src/main/java/com/example/skillmateai/entities/user/UserEntity.java
@@ -27,16 +27,17 @@ public class UserEntity {
     private String password;
 
     @NonNull
-    private String name;
+    private String firstName;
+    
+    private String lastName;
 
     private boolean isVerified;
     private boolean isAccountEnabled;
-    private long userCreationTime;
-
-    private long balance;
-
-    private ArrayList<String> userTokensId;
-
+    private Boolean isBlocked;
+    private String profilePictureUrl;
+    private String firebaseUid;
+    private long createdAt;
+    private long updatedAt;
     private ArrayList<String> roles;
 
 

--- a/backend/src/main/java/com/example/skillmateai/entities/user/UserPreferencesEntity.java
+++ b/backend/src/main/java/com/example/skillmateai/entities/user/UserPreferencesEntity.java
@@ -18,9 +18,9 @@ public class UserPreferencesEntity {
     private String userEmail;
     private String preferredLanguage;
     private String preferredTheme;
-    private String profilePictureUrl;
     private boolean pushNotificationsEnabled;
     private boolean emailNotificationsEnabled;
     private boolean subscribedToNewsletter;
+
 
 }

--- a/backend/src/main/java/com/example/skillmateai/services/user/UserVerificationService.java
+++ b/backend/src/main/java/com/example/skillmateai/services/user/UserVerificationService.java
@@ -34,9 +34,6 @@ public class UserVerificationService {
     @Autowired
     private CreateResponseUtil createResponseUtil;
 
-    @Autowired
-    private GetAuthenticatedUserUtil getAuthenticatedUserUtil;
-
     public UserVerificationEntity createUserVerificationEntity(String userEmail){
         UserVerificationEntity userVerificationEntity =
                 new UserVerificationEntity(GenerateAndValidateStringUtil.generateUniqueString(), userEmail, "", Instant.now());

--- a/backend/src/main/java/com/example/skillmateai/utilities/CreateResponseUtil.java
+++ b/backend/src/main/java/com/example/skillmateai/utilities/CreateResponseUtil.java
@@ -24,46 +24,6 @@ public class CreateResponseUtil {
         return response;
     }
 
-//    public Map createResponseBody(boolean success, String message, String email){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put("success", success);
-//        response.put("message", message);
-//        response.put("email", email);
-//        return response;
-//    }
-
-//    public Map createResponseBody(boolean success, String message, String error){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put("success", success);
-//        response.put("message", message);
-//        response.put("error", error);
-//        return response;
-//    }
-
-//    public Map createResponseBody(boolean success, String message, Map data){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put("success", success);
-//        response.put("message", message);
-//        response.put("data", data);
-//        return response;
-//    }
-
-//    public Map createResponseBody(boolean success, String message , Map userinfo){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put("success", success);
-//        response.put("message", message);
-//        response.put("data", data);
-//        return response;
-//    }
-
-//    public Map createResponseBody(boolean success, String message, String email, Map data){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put("success", success);
-//        response.put("message", message);
-//        response.put("email", email);
-//        response.put("data", data);
-//        return response;
-//    }
 
     public Map createResponseBody(boolean success, String message, String dataName, Object data) {
         Map<String, Object> response = new HashMap<>();
@@ -95,21 +55,15 @@ public class CreateResponseUtil {
         return response;
     }
 
-//    public Map createMap(String dataName1, Object data1, String dataName2, Object data2){
-//        Map<String, Object> response = new HashMap<>();
-//        response.put(dataName1, data1);
-//        response.put(dataName2, data2);
-//        return response;
-//    }
-
     public Map createUserInfoMap(UserEntity user) {
         try {
             Map<String, Object> userMap = new HashMap<>();
             userMap.put("email", user.getEmail());
-            userMap.put("name", user.getName());
+            userMap.put("firstName", user.getFirstName());
+            userMap.put("lastName", user.getLastName());
             userMap.put("isVerified", user.isVerified());
             userMap.put("isAccountEnabled", user.isAccountEnabled());
-            userMap.put("balance", user.getBalance());
+            userMap.put("isBlocked", user.getIsBlocked());
             return userMap;
 
         } catch (Exception e) {


### PR DESCRIPTION
UserEntity previously stored user's complete name in one string. Now it stores that in two parts. Also added some more attributes in UserEntity. Removed one attribute from UserPreferencesEntity. Made 32bit string id the primary key(id in mongodb) for UserEntites.

## Summary by Sourcery

Refactor user model to support separate firstName and lastName with new metadata, switch to string-based primary key, and update related controllers, services, and utilities.

Enhancements:
- Refactor UserEntity to use separate firstName and lastName, switch the primary key to a generated string id, add isBlocked, profilePictureUrl, firebaseUid, createdAt, and updatedAt, and remove deprecated fields (balance, tokens, userCreationTime).
- Update authentication and user controllers, service methods, and DTOs to handle firstName and lastName instead of a full name.
- Clean up CreateResponseUtil by removing legacy commented methods and update user info mapping to reflect the new entity fields.
- Remove profilePictureUrl from UserPreferencesEntity and drop unused GetAuthenticatedUserUtil injection in UserVerificationService.